### PR TITLE
Patch 1.1.2

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -71,3 +71,10 @@ data "oci_objectstorage_namespace" "ns" {
 data "oci_containerengine_cluster_kube_config" "oke_cluster_kube_config" {
   cluster_id = var.create_new_oke_cluster ? module.oci-oke[0].cluster.id : var.existent_oke_cluster_id
 }
+
+
+data "oci_load_balancer_load_balancers" "LBs" {
+  compartment_id = var.compartment_ocid
+  depends_on = [oci_devops_build_run.test_build_run_1]
+
+}

--- a/datasources.tf
+++ b/datasources.tf
@@ -71,15 +71,3 @@ data "oci_objectstorage_namespace" "ns" {
 data "oci_containerengine_cluster_kube_config" "oke_cluster_kube_config" {
   cluster_id = var.create_new_oke_cluster ? module.oci-oke[0].cluster.id : var.existent_oke_cluster_id
 }
-
-# Gets the OKE LB IP
-data "oci_load_balancer_load_balancers" "LBs" {
-  compartment_id = var.compartment_ocid
-  depends_on = [oci_devops_build_run.test_build_run_1]
-
-  filter {
-    name = "defined_tags.Oracle-Tags.CreatedBy"
-    values = [var.create_new_oke_cluster ? module.oci-oke[0].cluster.id : var.existent_oke_cluster_id]
-  }
-
-}

--- a/oke-outputs.tf
+++ b/oke-outputs.tf
@@ -29,3 +29,7 @@ output "kubeconfig_for_kubectl" {
   value       = "export KUBECONFIG=./generated/kubeconfig"
   description = "If using Terraform locally, this command set KUBECONFIG environment variable to run kubectl locally"
 }
+
+output "LB_IP" {
+  value = data.oci_load_balancer_load_balancers.LBs.load_balancers[0].ip_addresses
+}

--- a/oke-outputs.tf
+++ b/oke-outputs.tf
@@ -29,7 +29,3 @@ output "kubeconfig_for_kubectl" {
   value       = "export KUBECONFIG=./generated/kubeconfig"
   description = "If using Terraform locally, this command set KUBECONFIG environment variable to run kubectl locally"
 }
-
-output "LB_IP" {
-  value = data.oci_load_balancer_load_balancers.LBs.load_balancers[0].ip_addresses
-}

--- a/orm/variables.tf
+++ b/orm/variables.tf
@@ -18,7 +18,7 @@ variable "oci_user_authtoken" {}
 
 variable "release" {
   description = "Reference Architecture Release (OCI Architecture Center)"
-  default     = "1.1.1"
+  default     = "1.1.2"
 }
 
 variable "project_logging_config_retention_period_in_days" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "oci_user_authtoken" {}
 
 variable "release" {
   description = "Reference Architecture Release (OCI Architecture Center)"
-  default     = "1.1.1"
+  default     = "1.1.2"
 }
 
 variable "project_logging_config_retention_period_in_days" {


### PR DESCRIPTION
 Removed the LB outputs view,as there is no tag not inherited to LB (which is created by kubectly apply).

#17  